### PR TITLE
Added client library summary

### DIFF
--- a/ClientLibs.md
+++ b/ClientLibs.md
@@ -7,5 +7,5 @@ Access Libraries
 | [py-4chan](https://github.com/e000/py-4chan)  | Python       | Semi-stable       | Open Source   | No                | Yes         | Yes                    |
 | [t-mart chan](https://github.com/t-mart/chan) | Ruby         |                   | MIT           |                   |             |                        |  
 | [4ch](https://github.com/plausibility/4ch)    | Python       | Beta              | Open Source   |                   |             |                        |
-| [go-4chan-api](https://github.com/moshee/go-4chan-api) | Go  | Beta              | None Listed   |                   |             |                        |
+| [go-4chan-api](https://github.com/moshee/go-4chan-api) | Go  | Beta              | BSD           | Yes               | Partial     | Yes                    |
 | [4Chan-API.NET](https://github.com/lioncash/4Chan-API.NET) | C# | Beta           | WTFPL         |                   |             |                        |


### PR DESCRIPTION
This adds a separate doc with a table containing a first-stab at a list of libraries that take advantage of the 4chan JSON API. It may make more sense for this to be kept as a GitHub wiki page. 
