### PR TITLE
Small correction regarding the board page index range 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported request methods are: GET, HEAD, OPTIONS
 
 Questions? Please e-mail [api@4chan.org](mailto:api@4chan.org).
 
-*This guide was last updated December 10, 2014.*
+*This guide was last updated June 1, 2016.*
 
 ### API Rules ###
 
@@ -134,7 +134,7 @@ If there are no custom spoilers already in a thread, you can just random whateve
 ### Where are the files? ###
 
 Boards: http(s)://boards.4chan.org/`board`/  
-Indexes: http(s)://boards.4chan.org/`board`/`[1-10]` (# of pages varies per board, directory root is page 1)  
+Indexes: http(s)://boards.4chan.org/`board`/`[2-10]` (# of pages varies per board, omit number for directory root)  
 
 Threads: http(s)://boards.4chan.org/`board`/thread/`resto`  
 Replies: http(s)://boards.4chan.org/`board`/thread/`resto`#p`no`  

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported request methods are: GET, HEAD, OPTIONS
 
 Questions? Please e-mail [api@4chan.org](mailto:api@4chan.org).
 
-*This guide was last updated June 1, 2016.*
+*This guide was last updated December 10, 2014.*
 
 ### API Rules ###
 


### PR DESCRIPTION
> Indexes: http(s)://boards.4chan.org/ board / [1-10] 

Calling a board URL using '1' will result in a 404 error.