### PR TITLE
README fixes: last_modified update triggers, archived/archived_on fields missing

### DIFF
--- a/pages/Catalog.md
+++ b/pages/Catalog.md
@@ -42,7 +42,7 @@ The `catalog.json` file is a comprehensive list of all threads+attributes on a b
 | `images`        | `integer`      | `OP only` | Total number of image replies to a thread | `any integer` |
 | `bumplimit`     | `integer`      | `OP only, only if bump limit has been reached` | If a thread has reached bumplimit, it will no longer bump | `1` or not set |
 | `imagelimit`    | `integer`      | `OP only, only if image limit has been reached` | If an image has reached image limit, no more image replies can be made  | `1` or not set |
-| `last_modified` | `integer`      | `OP only` | The UNIX timestamp marking the last time a post was added to or removed from a thread | `UNIX Timestamp` |
+| `last_modified` | `integer`      | `OP only` | The UNIX timestamp marking the last time the thread was modified (post added/modified/deleted, thread closed/sticky settings modified) | `UNIX Timestamp` |
 | `tag`           | `string`       | `OP only`, `/f/ only` | The category of `.swf` upload |`Game`, `Loop`, etc..|
 | `semantic_url`  | `string`       |  `OP only` | SEO URL slug for thread | `string` |
 | `since4pass`    | `integer`      | `if poster put 'since4pass' in the options field` | Year 4chan pass bought | `any 4 digit year`|

--- a/pages/Indexes.md
+++ b/pages/Indexes.md
@@ -41,7 +41,7 @@
 | `images`        | `integer`      | `OP only` | Total number of image replies to a thread | `any integer` |
 | `bumplimit`     | `integer`      | `OP only, only if bump limit has been reached` | If a thread has reached bumplimit, it will no longer bump | `1` or not set |
 | `imagelimit`    | `integer`      | `OP only, only if image limit has been reached` | If an image has reached image limit, no more image replies can be made  | `1` or not set |
-| `last_modified` | `integer`      | `OP only` | The UNIX timestamp marking the last time a post was added to or removed from a thread | `UNIX Timestamp` |
+| `last_modified` | `integer`      | `OP only` | The UNIX timestamp marking the last time the thread was modified (post added/modified/deleted, thread closed/sticky settings modified) | `UNIX Timestamp` |
 | `tag`           | `string`       | `OP only`, `/f/ only` | The category of `.swf` upload |`Game`, `Loop`, etc..|
 | `semantic_url`  | `string`       |  `OP only` | SEO URL slug for thread | `string` |
 | `since4pass`    | `integer`      | `if poster put 'since4pass' in the options field` | Year 4chan pass bought | `any 4 digit year`|

--- a/pages/Threadlist.md
+++ b/pages/Threadlist.md
@@ -6,7 +6,7 @@
 The `threads.json` file is a comprehensive list of all threads that contains:
  - The thread OP number
  - The index page the thread is currently on
- - A [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) marking the last time the thread was updated; this could be a new post, a post deletion, a post image deletion, a post moderation text edit, or a thread-level settings modification (closed/sticky toggle)
+ - A [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) marking the last time the thread was modified
  - The number of replies a thread has
 
 

--- a/pages/Threadlist.md
+++ b/pages/Threadlist.md
@@ -6,7 +6,7 @@
 The `threads.json` file is a comprehensive list of all threads that contains:
  - The thread OP number
  - The index page the thread is currently on
- - A [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) marking the last time a post was removed **or** added to the thread was last updated
+ - A [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) marking the last time the thread was updated; this could be a new post, a post deletion, a post image deletion, a post moderation text edit, or a thread-level settings modification (closed/sticky toggle)
  - The number of replies a thread has
 
 
@@ -17,7 +17,7 @@ The `threads.json` file is a comprehensive list of all threads that contains:
 | `page`          | `integer`      | `always` | The page number that the following `threads` array is on | `Any positive integer` |
 | `threads`       | `array`        | `always` | The array of thread objects | `array of objects`|
 | `no`            | `integer`      | `always` | The OP ID of a thread | `Any positive integer` |
-| `last_modified` | `integer` (Unix timestamp)| `always` | The UNIX timestamp when a post was last added or deleted from the thread | `UNIX Timestamp` |
+| `last_modified` | `integer`      | `always` | The UNIX timestamp marking the last time the thread was modified (post added/modified/deleted, thread closed/sticky settings modified) | `UNIX Timestamp` |
 | `replies`       | `integer`      | `always` | A numeric count of the number of replies in the thread | `Any positive integer` |
 
 * integer 1 = (on) or 0 (off)

--- a/pages/Threads.md
+++ b/pages/Threads.md
@@ -46,6 +46,8 @@
 | `since4pass`    | `integer`      | `if poster put 'since4pass' in the options field` | Year 4chan pass bought | `any 4 digit year`|
 | `unique_ips`    | `integer`      | `OP only` | Number of unique posters in a thread  | `any integer` | 
 | `m_img`         | `integer`      | `any post that has a mobile-optimized image` | Mobile optimized image exists for post | `1` or not set |
+| `archived`      | `integer`      | `OP only, if thread has been archived` | Thread has reached the board's archive | `1` or not set |
+| `archived_on`   | `integer`      | `OP only, if thread has been archived` | UNIX timestamp the post was archived | `UNIX timestamp` |
 
 
 


### PR DESCRIPTION
Adds info about other triggers for last_modified field updates which were missing (post edits, thread setting changes) in Catalog.md, Indexes.md and Threadlist.md. Info taken from #45.

Comment if you think the information could be integrated better.