### PR TITLE
Link Mismatch Fix.md

### DIFF
--- a/pages/Archive.md
+++ b/pages/Archive.md
@@ -1,5 +1,5 @@
 ## Archive.json ##
-| **Example url** | [`https://a.4cdn.org/po/archive.json`](https://a.4cdn.org/archive.json) | 
+| **Example url** | [`https://a.4cdn.org/po/archive.json`](https://a.4cdn.org/po/archive.json) | 
 |:----------------|:-------------------------------------|
 | **Status 200**  | Content-Type: application/json |
 


### PR DESCRIPTION
The hyperlink to the example didn't work because it was missing a "/po" which the text version of the link did.